### PR TITLE
fix: keep timestamps when removing resources

### DIFF
--- a/kafka/schemas/no.fdk.rdf.parse.ConceptEvent.avsc
+++ b/kafka/schemas/no.fdk.rdf.parse.ConceptEvent.avsc
@@ -13,6 +13,6 @@
         },
         {"name": "fdkId", "type": "string"},
         {"name": "graph", "type": "string"},
-        {"name": "timestamp", "type": "long", "logicalType": "timestamp-millis"}
+        {"name": "timestamp", "type": "long"}
     ]
 }

--- a/kafka/schemas/no.fdk.rdf.parse.DataServiceEvent.avsc
+++ b/kafka/schemas/no.fdk.rdf.parse.DataServiceEvent.avsc
@@ -13,6 +13,6 @@
         },
         {"name": "fdkId", "type": "string"},
         {"name": "graph", "type": "string"},
-        {"name": "timestamp", "type": "long", "logicalType": "timestamp-millis"}
+        {"name": "timestamp", "type": "long"}
     ]
 }

--- a/kafka/schemas/no.fdk.rdf.parse.DatasetEvent.avsc
+++ b/kafka/schemas/no.fdk.rdf.parse.DatasetEvent.avsc
@@ -13,6 +13,6 @@
         },
         {"name": "fdkId", "type": "string"},
         {"name": "graph", "type": "string"},
-        {"name": "timestamp", "type": "long", "logicalType": "timestamp-millis"}
+        {"name": "timestamp", "type": "long"}
     ]
 }

--- a/kafka/schemas/no.fdk.rdf.parse.EventEvent.avsc
+++ b/kafka/schemas/no.fdk.rdf.parse.EventEvent.avsc
@@ -13,6 +13,6 @@
         },
         {"name": "fdkId", "type": "string"},
         {"name": "graph", "type": "string"},
-        {"name": "timestamp", "type": "long", "logicalType": "timestamp-millis"}
+        {"name": "timestamp", "type": "long"}
     ]
 }

--- a/kafka/schemas/no.fdk.rdf.parse.InformationModelEvent.avsc
+++ b/kafka/schemas/no.fdk.rdf.parse.InformationModelEvent.avsc
@@ -13,6 +13,6 @@
         },
         {"name": "fdkId", "type": "string"},
         {"name": "graph", "type": "string"},
-        {"name": "timestamp", "type": "long", "logicalType": "timestamp-millis"}
+        {"name": "timestamp", "type": "long"}
     ]
 }

--- a/kafka/schemas/no.fdk.rdf.parse.ServiceEvent.avsc
+++ b/kafka/schemas/no.fdk.rdf.parse.ServiceEvent.avsc
@@ -13,6 +13,6 @@
         },
         {"name": "fdkId", "type": "string"},
         {"name": "graph", "type": "string"},
-        {"name": "timestamp", "type": "long", "logicalType": "timestamp-millis"}
+        {"name": "timestamp", "type": "long"}
     ]
 }

--- a/src/main/java/no/fdk/concept/ConceptEvent.java
+++ b/src/main/java/no/fdk/concept/ConceptEvent.java
@@ -17,7 +17,7 @@ public class ConceptEvent extends org.apache.avro.specific.SpecificRecordBase im
   private static final long serialVersionUID = 5396894262983787152L;
 
 
-  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ConceptEvent\",\"namespace\":\"no.fdk.concept\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"ConceptEventType\",\"symbols\":[\"CONCEPT_REASONED\",\"CONCEPT_REMOVED\",\"CONCEPT_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}]}");
+  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ConceptEvent\",\"namespace\":\"no.fdk.concept\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"ConceptEventType\",\"symbols\":[\"CONCEPT_REASONED\",\"CONCEPT_REMOVED\",\"CONCEPT_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\"}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
 
   private static final SpecificData MODEL$ = new SpecificData();

--- a/src/main/java/no/fdk/dataservice/DataServiceEvent.java
+++ b/src/main/java/no/fdk/dataservice/DataServiceEvent.java
@@ -17,7 +17,7 @@ public class DataServiceEvent extends org.apache.avro.specific.SpecificRecordBas
   private static final long serialVersionUID = -3967351634015063740L;
 
 
-  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"DataServiceEvent\",\"namespace\":\"no.fdk.dataservice\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"DataServiceEventType\",\"symbols\":[\"DATA_SERVICE_REASONED\",\"DATA_SERVICE_REMOVED\",\"DATA_SERVICE_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}]}");
+  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"DataServiceEvent\",\"namespace\":\"no.fdk.dataservice\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"DataServiceEventType\",\"symbols\":[\"DATA_SERVICE_REASONED\",\"DATA_SERVICE_REMOVED\",\"DATA_SERVICE_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\"}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
 
   private static final SpecificData MODEL$ = new SpecificData();

--- a/src/main/java/no/fdk/dataset/DatasetEvent.java
+++ b/src/main/java/no/fdk/dataset/DatasetEvent.java
@@ -17,7 +17,7 @@ public class DatasetEvent extends org.apache.avro.specific.SpecificRecordBase im
   private static final long serialVersionUID = 1262248989782269649L;
 
 
-  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"DatasetEvent\",\"namespace\":\"no.fdk.dataset\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"DatasetEventType\",\"symbols\":[\"DATASET_REASONED\",\"DATASET_REMOVED\",\"DATASET_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}]}");
+  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"DatasetEvent\",\"namespace\":\"no.fdk.dataset\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"DatasetEventType\",\"symbols\":[\"DATASET_REASONED\",\"DATASET_REMOVED\",\"DATASET_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\"}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
 
   private static final SpecificData MODEL$ = new SpecificData();

--- a/src/main/java/no/fdk/event/EventEvent.java
+++ b/src/main/java/no/fdk/event/EventEvent.java
@@ -17,7 +17,7 @@ public class EventEvent extends org.apache.avro.specific.SpecificRecordBase impl
   private static final long serialVersionUID = -8707172071964816401L;
 
 
-  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"EventEvent\",\"namespace\":\"no.fdk.event\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"EventEventType\",\"symbols\":[\"EVENT_REASONED\",\"EVENT_REMOVED\",\"EVENT_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}]}");
+  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"EventEvent\",\"namespace\":\"no.fdk.event\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"EventEventType\",\"symbols\":[\"EVENT_REASONED\",\"EVENT_REMOVED\",\"EVENT_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\"}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
 
   private static final SpecificData MODEL$ = new SpecificData();

--- a/src/main/java/no/fdk/informationmodel/InformationModelEvent.java
+++ b/src/main/java/no/fdk/informationmodel/InformationModelEvent.java
@@ -17,7 +17,7 @@ public class InformationModelEvent extends org.apache.avro.specific.SpecificReco
   private static final long serialVersionUID = 2972092679633082473L;
 
 
-  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"InformationModelEvent\",\"namespace\":\"no.fdk.informationmodel\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"InformationModelEventType\",\"symbols\":[\"INFORMATION_MODEL_REASONED\",\"INFORMATION_MODEL_REMOVED\",\"INFORMATION_MODEL_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}]}");
+  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"InformationModelEvent\",\"namespace\":\"no.fdk.informationmodel\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"InformationModelEventType\",\"symbols\":[\"INFORMATION_MODEL_REASONED\",\"INFORMATION_MODEL_REMOVED\",\"INFORMATION_MODEL_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\"}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
 
   private static final SpecificData MODEL$ = new SpecificData();

--- a/src/main/java/no/fdk/service/ServiceEvent.java
+++ b/src/main/java/no/fdk/service/ServiceEvent.java
@@ -17,7 +17,7 @@ public class ServiceEvent extends org.apache.avro.specific.SpecificRecordBase im
   private static final long serialVersionUID = -2429256536450842638L;
 
 
-  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ServiceEvent\",\"namespace\":\"no.fdk.service\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"ServiceEventType\",\"symbols\":[\"SERVICE_REASONED\",\"SERVICE_REMOVED\",\"SERVICE_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}]}");
+  public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ServiceEvent\",\"namespace\":\"no.fdk.service\",\"fields\":[{\"name\":\"type\",\"type\":{\"type\":\"enum\",\"name\":\"ServiceEventType\",\"symbols\":[\"SERVICE_REASONED\",\"SERVICE_REMOVED\",\"SERVICE_HARVESTED\"]}},{\"name\":\"fdkId\",\"type\":\"string\"},{\"name\":\"graph\",\"type\":\"string\"},{\"name\":\"timestamp\",\"type\":\"long\"}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
 
   private static final SpecificData MODEL$ = new SpecificData();

--- a/src/main/java/no/fdk/sparqlservice/kafka/KafkaEventCircuitBreakers.java
+++ b/src/main/java/no/fdk/sparqlservice/kafka/KafkaEventCircuitBreakers.java
@@ -39,7 +39,7 @@ public class KafkaEventCircuitBreakers {
                         event.getTimestamp()
                 );
             } else if(event.getType() == ServiceEventType.SERVICE_REMOVED && hasHigherTimestamp) {
-                resourceService.deleteService(event.getFdkId().toString());
+                resourceService.saveService(event.getFdkId().toString(), "", event.getTimestamp());
             }
         } catch (ClassCastException exception) {
             log.error("Skipping unknown event",  exception);
@@ -61,7 +61,7 @@ public class KafkaEventCircuitBreakers {
                         event.getTimestamp()
                 );
             } else if(event.getType() == InformationModelEventType.INFORMATION_MODEL_REMOVED && hasHigherTimestamp) {
-                resourceService.deleteInformationModel(event.getFdkId().toString());
+                resourceService.saveInformationModel(event.getFdkId().toString(), "", event.getTimestamp());
             }
         } catch (ClassCastException exception) {
             log.error("Skipping unknown event",  exception);
@@ -83,7 +83,7 @@ public class KafkaEventCircuitBreakers {
                         kafkaEvent.getTimestamp()
                 );
             } else if(kafkaEvent.getType() == EventEventType.EVENT_REMOVED && hasHigherTimestamp) {
-                resourceService.deleteEvent(kafkaEvent.getFdkId().toString());
+                resourceService.saveEvent(kafkaEvent.getFdkId().toString(), "", kafkaEvent.getTimestamp());
             }
         } catch (ClassCastException exception) {
             log.error("Skipping unknown event",  exception);
@@ -105,7 +105,7 @@ public class KafkaEventCircuitBreakers {
                         event.getTimestamp()
                 );
             } else if(event.getType() == DatasetEventType.DATASET_REMOVED && hasHigherTimestamp) {
-                resourceService.deleteDataset(event.getFdkId().toString());
+                resourceService.saveDataset(event.getFdkId().toString(), "", event.getTimestamp());
             }
         } catch (ClassCastException exception) {
             log.error("Skipping unknown event",  exception);
@@ -127,7 +127,7 @@ public class KafkaEventCircuitBreakers {
                         event.getTimestamp()
                 );
             } else if(event.getType() == DataServiceEventType.DATA_SERVICE_REMOVED && hasHigherTimestamp) {
-                resourceService.deleteDataService(event.getFdkId().toString());
+                resourceService.saveDataService(event.getFdkId().toString(), "", event.getTimestamp());
             }
         } catch (ClassCastException exception) {
             log.error("Skipping unknown event",  exception);
@@ -149,7 +149,7 @@ public class KafkaEventCircuitBreakers {
                         event.getTimestamp()
                 );
             } else if(event.getType() == ConceptEventType.CONCEPT_REMOVED && hasHigherTimestamp) {
-                resourceService.deleteConcept(event.getFdkId().toString());
+                resourceService.saveConcept(event.getFdkId().toString(), "", event.getTimestamp());
             }
         } catch (ClassCastException exception) {
             log.error("Skipping unknown event",  exception);

--- a/src/main/java/no/fdk/sparqlservice/service/ResourceService.java
+++ b/src/main/java/no/fdk/sparqlservice/service/ResourceService.java
@@ -56,13 +56,6 @@ public class ResourceService {
     }
 
     @Transactional
-    public void deleteConcept(String fdkId) {
-        if (conceptRepository.existsById(fdkId)) {
-            conceptRepository.deleteById(fdkId);
-        }
-    }
-
-    @Transactional
     public void saveDataService(String fdkId, String graph, long timestamp) {
         DataService dataService = new DataService(fdkId, graph, timestamp);
         dataServiceRepository.save(dataService);
@@ -71,13 +64,6 @@ public class ResourceService {
 
     public List<DataService> findAllDataServices() {
         return dataServiceRepository.findAll();
-    }
-
-    @Transactional
-    public void deleteDataService(String fdkId) {
-        if (dataServiceRepository.existsById(fdkId)) {
-            dataServiceRepository.deleteById(fdkId);
-        }
     }
 
     @Transactional
@@ -92,13 +78,6 @@ public class ResourceService {
     }
 
     @Transactional
-    public void deleteDataset(String fdkId) {
-        if (datasetRepository.existsById(fdkId)) {
-            datasetRepository.deleteById(fdkId);
-        }
-    }
-
-    @Transactional
     public void saveEvent(String fdkId, String graph, long timestamp) {
         Event fdkEvent = new Event(fdkId, graph, timestamp);
         eventRepository.save(fdkEvent);
@@ -107,13 +86,6 @@ public class ResourceService {
 
     public List<Event> findAllEvents() {
         return eventRepository.findAll();
-    }
-
-    @Transactional
-    public void deleteEvent(String fdkId) {
-        if (eventRepository.existsById(fdkId)) {
-            eventRepository.deleteById(fdkId);
-        }
     }
 
     @Transactional
@@ -128,13 +100,6 @@ public class ResourceService {
     }
 
     @Transactional
-    public void deleteInformationModel(String fdkId) {
-        if (informationModelRepository.existsById(fdkId)) {
-            informationModelRepository.deleteById(fdkId);
-        }
-    }
-
-    @Transactional
     public void saveService(String fdkId, String graph, long timestamp) {
         no.fdk.sparqlservice.model.Service service = new no.fdk.sparqlservice.model.Service(fdkId, graph, timestamp);
         serviceRepository.save(service);
@@ -143,13 +108,6 @@ public class ResourceService {
 
     public List<no.fdk.sparqlservice.model.Service> findAllServices() {
         return serviceRepository.findAll();
-    }
-
-    @Transactional
-    public void deleteService(String fdkId) {
-        if (serviceRepository.existsById(fdkId)) {
-            serviceRepository.deleteById(fdkId);
-        }
     }
 
     public boolean timestampIsHigherThanSaved(String fdkId, long timestamp, CatalogType type) {

--- a/src/test/java/no/fdk/sparqlservice/integration/IntegrationTest.java
+++ b/src/test/java/no/fdk/sparqlservice/integration/IntegrationTest.java
@@ -53,6 +53,24 @@ public class IntegrationTest extends AbstractContainerTest {
     UpdateService updateService;
 
     @Autowired
+    ConceptRepository conceptRepository;
+
+    @Autowired
+    DataServiceRepository dataServiceRepository;
+
+    @Autowired
+    DatasetRepository datasetRepository;
+
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    InformationModelRepository informationModelRepository;
+
+    @Autowired
+    ServiceRepository serviceRepository;
+
+    @Autowired
     ResourceService resourceService;
 
     @Autowired
@@ -60,12 +78,12 @@ public class IntegrationTest extends AbstractContainerTest {
 
     @BeforeEach
     void setup() {
-        resourceService.findAllDatasets().forEach(dataset -> resourceService.deleteDataset(dataset.getId()));
-        resourceService.findAllDataServices().forEach(dataService -> resourceService.deleteDataService(dataService.getId()));
-        resourceService.findAllConcepts().forEach(concept -> resourceService.deleteConcept(concept.getId()));
-        resourceService.findAllEvents().forEach(event -> resourceService.deleteEvent(event.getId()));
-        resourceService.findAllInformationModels().forEach(informationModel -> resourceService.deleteInformationModel(informationModel.getId()));
-        resourceService.findAllServices().forEach(service -> resourceService.deleteService(service.getId()));
+        conceptRepository.deleteAll();
+        dataServiceRepository.deleteAll();
+        datasetRepository.deleteAll();
+        eventRepository.deleteAll();
+        informationModelRepository.deleteAll();
+        serviceRepository.deleteAll();
 
         resourceService.saveConcept("0", ResourceReader.readFile("concept0.ttl"), 123);
         resourceService.saveConcept("1", ResourceReader.readFile("concept1.ttl"), 123);
@@ -117,7 +135,7 @@ public class IntegrationTest extends AbstractContainerTest {
 
     @Test
     void deleteConcept() throws JsonProcessingException {
-        resourceService.deleteConcept("1");
+        resourceService.saveConcept("1", "", 124);
         updateService.updateConcepts();
 
         String response = TestQuery.sendQuery(countQuery("skos:Concept"));
@@ -134,7 +152,7 @@ public class IntegrationTest extends AbstractContainerTest {
 
     @Test
     void deleteDataService() throws JsonProcessingException {
-        resourceService.deleteDataService("1");
+        resourceService.saveDataService("1", "", 124);
         updateService.updateDataServices();
 
         String response = TestQuery.sendQuery(countQuery("dcat:DataService"));
@@ -151,7 +169,7 @@ public class IntegrationTest extends AbstractContainerTest {
 
     @Test
     void deleteDataset() throws JsonProcessingException {
-        resourceService.deleteDataset("1");
+        resourceService.saveDataset("1", "", 124);
         updateService.updateDatasets();
 
         String response = TestQuery.sendQuery(countQuery("dcat:Dataset"));
@@ -172,7 +190,7 @@ public class IntegrationTest extends AbstractContainerTest {
 
     @Test
     void deleteEvent() throws JsonProcessingException {
-        resourceService.deleteEvent("0");
+        resourceService.saveEvent("0", "", 124);
         updateService.updateEvents();
 
         String businessResponse = TestQuery.sendQuery(countQuery("cv:BusinessEvent"));
@@ -189,7 +207,7 @@ public class IntegrationTest extends AbstractContainerTest {
 
     @Test
     void deleteInformationModel() throws JsonProcessingException {
-        resourceService.deleteInformationModel("1");
+        resourceService.saveInformationModel("1", "", 124);
         updateService.updateInformationModels();
 
         String response = TestQuery.sendQuery(countQuery("modelldcatno:InformationModel"));
@@ -206,7 +224,7 @@ public class IntegrationTest extends AbstractContainerTest {
 
     @Test
     void deleteService() throws JsonProcessingException {
-        resourceService.deleteService("1");
+        resourceService.saveService("1", "", 124);
         updateService.updateServices();
 
         String response = TestQuery.sendQuery(countQuery("cpsv:PublicService"));


### PR DESCRIPTION
Vi har litt feil tall i sparql, og det ser ut til å være fordi vi sletter ressursene helt på remove-meldinger.

Så når en reason-melding kommer senere i rekkefølgen, men med eldre timestamp, så blir den lagt til igjen selv om den egentlig burde ignorert den meldingen.

Går over til å bare tømme grafene på remove-meldingen, blir funksjonelt likt mtp fuseki. Dette er samme strategi vi bruker i fdk-search-service