### PR TITLE
chore: align codeql with central setup

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   pull_request:
-    types: [ ready_for_review, opened, reopened, synchronize ]
+    types: [ready_for_review, opened, reopened, synchronize]
     branches:
       - main
   push:
@@ -22,6 +22,6 @@ jobs:
     uses: Informasjonsforvaltning/workflows/.github/workflows/codeql.yaml@main
     with:
       language: java
-      java_version: 21
+      java_version: '21'
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary

- Quote `java_version` as a string and normalize list formatting in `codeql.yaml` to match the central reusable-workflow template used across the Kotlin/Java repos
- CodeQL is already enrolled in the central setup (PR #112) and runs daily; GitHub default setup stays disabled, as agreed for Java apps in fdk-team-private#130

Closes #97